### PR TITLE
Implement array access for string and number variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@
 * [x] GOSUB, RETURN
 * [x] REM, LEN
 * [x] CR/LF , DEL, sur ESP01-1M
-* [ ] TO en opérande gauche LET A$(1 TO 2) = "AB"
-* [ ] DIM
+* [x] TO en opérande gauche LET A$(1 TO 2) = "AB"
+* [x] DIM
 * [ ] Support Suite / Retour / Sommaire (TAB ou PGDN / SHIFT TAB ou PGDUP/ HOME)
 * [ ] Régler le pb du nom mDNS de l'ESP quand il vient d'être flashé par USB serial
 * [ ] tty : init string, fast, autoexec => config$$$
@@ -59,7 +59,7 @@
 * [ ] Optimisation BIO (une seule structure, 1 fonction number (int), 2/3 params
   (union as_void_ptr, as_char_ptr, as_int, as_float), 1 result (union like
   param) => static / extern
-* [ ] Tableaux (DIM)
+* [x] Tableaux (DIM)
 * [ ] EVAL / EVAL$
 * [ ] PLOT / UNPLOT / SCREEN$(l,c) ?
 * [ ] DOWNLOAD / UPLOAD
@@ -77,6 +77,7 @@
   * [ ] Pouvoir sauvegarder uniquement les variables (config manager, "SAVE VARS")
   * [ ] Faire un config manager plus complet (vitesse port Minitel par exemple) ?
 * [ ] **OPTIMISATIONS** (valable aussi pour la version OTA only)
+  * [ ] Optimisation accès tableau / variable (factorisation number / string, name)
   * [x] Rapporter tout le basic sauf l'API bastos dans un seul fichier et static
     functions (notamment memory)
   * [x] Global Memory Management

--- a/lib/basic/bio.c
+++ b/lib/basic/bio.c
@@ -53,7 +53,6 @@ bastos_io_t *bio = 0;
 void bastos_init(bastos_io_t *_io)
 {
     bio = _io;
-    *bmem->io_buffer = 0;
     bmem_init(malloc(BASTOS_MEMORY_SIZE), BASTOS_MEMORY_SIZE);
 }
 

--- a/lib/basic/bmemory.c-static
+++ b/lib/basic/bmemory.c-static
@@ -256,17 +256,16 @@ static float *bmem_number_array_get_cell(const char *name, uint8_t dim_count, ui
     if (var->dim_count != dim_count)
         return 0;
 
-
-    uint16_t offset = 0;
-    for (uint8_t i = 1; i < var->dim_count; i++)
-    {
-        uint16_t indice = indexes[i - 1] - 1;
-        if (indice >= var->dims[i - 1])
+    // check dims
+    for (uint8_t i = 0; i < dim_count; i++)
+        if (indexes[i] > var->dims[i])
             return 0;
 
-        offset = (offset + indice) * var->dims[i];
-    }
-    offset += var->dim_count + indexes[var->dim_count - 1] - 1;
+    uint16_t offset = 0;
+    for (uint8_t i = 0; i < dim_count - 1; i++)
+        offset = (offset + indexes[i] - 1) * var->dims[i + 1];
+    offset += indexes[dim_count - 1] - 1;
+    offset += dim_count;
 
     return &var->numbers[offset];
 }
@@ -329,15 +328,15 @@ static char *bmem_string_array_get_cell(const char *name, uint8_t *dim_count, ui
         return 0;
     }
 
-    uint16_t offset = 0;
-    for (uint8_t i = 1; i < var->dim_count; i++)
-    {
-        uint16_t indice = indexes[i - 1] - 1;
-        if (indice >= var->dims[i - 1])
+    // check dims
+    uint8_t dim = var->dim_count - 1;
+    for (uint8_t i = 0; i < dim; i++)
+        if (indexes[i] > var->dims[i])
             return 0;
 
-        offset = (offset + indice) * var->dims[i];
-    }
+    uint16_t offset = 0;
+    for (uint8_t i = 0; i < dim; i++)
+        offset = (offset + indexes[i] - 1) * var->dims[i + 1];
     offset += var->dim_count * sizeof(uint32_t);
 
     *dim_count = dim_asked + 2;

--- a/lib/basic/bmemory.c-static
+++ b/lib/basic/bmemory.c-static
@@ -231,6 +231,32 @@ static var_t *bmem_var_number_set(const char *name, float value)
     return var;
 }
 
+static float *bmem_number_array_get_cell(const char *name, uint8_t dim_count, uint32_t *indexes)
+{
+    // Copy name in tmp
+    char tmp[B_NAME_SIZE_MAX];
+    strncpy(tmp, name, B_NAME_SIZE_MAX - 1);
+    tmp[B_NAME_SIZE_MAX - 1] = 0;
+    tmp[0] |= TOKEN_ARRAY_FLAG;
+
+    var_t *var = bmem_var_find(tmp);
+    if (var == 0)
+        return 0;
+
+    if (var->dim_count != dim_count)
+        return 0;
+
+    int offset = var->dim_count;
+    for (int i = 0; i < dim_count; i++)
+    {
+        if (indexes[i] > var->dims[i] || indexes[i] == 0)
+            return 0;
+        offset += (indexes[i] - 1) * (i < dim_count - 1 ? var->dims[i + 1] : 1);
+    }
+
+    return &var->numbers[offset];
+}
+
 // Clear the program and the variables memory
 void bmem_prog_new()
 {

--- a/lib/basic/bmemory.c-static
+++ b/lib/basic/bmemory.c-static
@@ -284,7 +284,11 @@ static char *bmem_string_array_get_cell(const char *name, uint8_t *dim_count, ui
     var_t *var = bmem_var_find(name);
     if (var)
     {
-        if (dim_asked == 1)
+        if (dim_asked == 0)
+        {
+            return var->string;
+        }
+        else if (dim_asked == 1)
         {
             indexes[1] = indexes[0];
         }

--- a/lib/basic/bmemory.c-static
+++ b/lib/basic/bmemory.c-static
@@ -63,7 +63,7 @@ static char *bmem_string_alloc(uint16_t size)
 }
 
 // Allocate a variable in the memory, set memory to 0 and return the variable
-static var_t *bmem_var_alloc(uint16_t size)
+static var_t *bmem_var_alloc(uint8_t token, uint16_t size)
 {
     int psize = bmem_align4(size);
     // printf("Allocating %d bytes\n", psize);
@@ -71,7 +71,8 @@ static var_t *bmem_var_alloc(uint16_t size)
         return 0;
 
     bmem->vars_start -= psize;
-    memset(bmem->vars_start, 0, psize);
+    int empty = token == TOKEN_ARRAY_STRING ? ' ' : 0;
+    memset(bmem->vars_start, empty, psize);
     return (var_t *)bmem->vars_start;
 }
 
@@ -116,7 +117,7 @@ static var_t *bmem_var_new(const char *name, uint8_t token, uint8_t dim_count, u
     int dims_size = dims ? dim_count * sizeof(uint32_t) : 0;
 
     // Allocate var
-    var_t *var = bmem_var_alloc(sizeof(var_t) + dims_size + data_size + name_size);
+    var_t *var = bmem_var_alloc(token, sizeof(var_t) + dims_size + data_size + name_size);
     if (!var)
         return 0;
 
@@ -137,6 +138,15 @@ static var_t *bmem_var_new(const char *name, uint8_t token, uint8_t dim_count, u
 
     // Copy name
     memcpy(var->bytes + var->name_ofs, name, name_size);
+
+    if (token == TOKEN_ARRAY_STRING)
+    {
+        // Set null char in all string cells
+        int string_size = dims[dim_count - 1];
+        char *string = (char *) var->bytes + dims_size + string_size - 1;
+        for (; string < (char *) var->bytes + var->name_ofs; string += string_size)
+            *string = 0;
+    }
 
     return var;
 }
@@ -246,15 +256,88 @@ static float *bmem_number_array_get_cell(const char *name, uint8_t dim_count, ui
     if (var->dim_count != dim_count)
         return 0;
 
-    int offset = var->dim_count;
-    for (int i = 0; i < dim_count; i++)
+
+    uint16_t offset = 0;
+    for (uint8_t i = 1; i < var->dim_count; i++)
     {
-        if (indexes[i] > var->dims[i] || indexes[i] == 0)
+        uint16_t indice = indexes[i - 1] - 1;
+        if (indice >= var->dims[i - 1])
             return 0;
-        offset += (indexes[i] - 1) * (i < dim_count - 1 ? var->dims[i + 1] : 1);
+
+        offset = (offset + indice) * var->dims[i];
     }
+    offset += var->dim_count + indexes[var->dim_count - 1] - 1;
 
     return &var->numbers[offset];
+}
+
+static char *bmem_string_array_get_cell(const char *name, uint8_t *dim_count, uint32_t *indexes)
+{
+    // Copy name in tmp
+    char tmp[B_NAME_SIZE_MAX];
+    strncpy(tmp, name, B_NAME_SIZE_MAX - 1);
+    tmp[B_NAME_SIZE_MAX - 1] = 0;
+
+    uint8_t dim_asked = *dim_count & ~B_DIM_RANGE_FLAG;
+
+    // Search simple string variable
+    var_t *var = bmem_var_find(name);
+    if (var)
+    {
+        if (dim_asked == 1)
+        {
+            indexes[1] = indexes[0];
+        }
+        else if (dim_asked != 2)
+        {
+            return 0;
+        }
+        *dim_count = 2;
+        return var->string;
+    }
+
+    // Search array string variable
+    tmp[0] |= TOKEN_ARRAY_FLAG;
+    var = bmem_var_find(tmp);
+    if (var == 0)
+        return 0;
+
+    // If asked dims is equal to var->dim_count - 1, the result is a slice of
+    // all chars of the string at given index
+    if (dim_asked == var->dim_count - 1)
+    {
+        indexes[dim_asked] = 1;
+        indexes[dim_asked + 1] = var->dims[dim_asked];
+    }
+    else if (dim_asked == var->dim_count)
+    {
+        // If asked dims is equal to var->dim_count, the result is a slice of one char
+        indexes[dim_asked] = indexes[dim_asked - 1];
+        dim_asked--;
+    }
+    else if (dim_asked == var->dim_count + 1)
+    {
+        // If asked dims is equal to var->dim_count + 1, the result is a slice
+        dim_asked -= 2;
+    }
+    else
+    {
+        return 0;
+    }
+
+    uint16_t offset = 0;
+    for (uint8_t i = 1; i < var->dim_count; i++)
+    {
+        uint16_t indice = indexes[i - 1] - 1;
+        if (indice >= var->dims[i - 1])
+            return 0;
+
+        offset = (offset + indice) * var->dims[i];
+    }
+    offset += var->dim_count * sizeof(uint32_t);
+
+    *dim_count = dim_asked + 2;
+    return (char *) &var->bytes[offset];
 }
 
 // Clear the program and the variables memory
@@ -396,6 +479,8 @@ static void bmem_init(uint8_t *mem, uint16_t size)
     bmem_prog_new();
 }
 
+#if 0
+
 #include <assert.h>
 
 void print_sizes()
@@ -411,8 +496,6 @@ void print_sizes()
     printf("Prog size: %zd bytes\n", bmem->prog_end - bmem->prog_start);
     printf("----\n");
 }
-
-#if 0
 
 void bmem_test()
 {

--- a/lib/basic/bmemory.c-static
+++ b/lib/basic/bmemory.c-static
@@ -200,12 +200,10 @@ static var_t *bmem_var_string_set(const char *name, char *value)
     if (var != 0)
         bmem_var_unset(var);
 
-    // Copy the name
-    // FIXME: create a temporary buffer in the bmem_t structure or in global
-    // memory
-    char tmp[32];
-    strncpy(tmp, name, sizeof(tmp) - 1);
-    tmp[sizeof(tmp) - 1] = 0;
+    // Copy the name in tmp
+    char tmp[B_NAME_SIZE_MAX];
+    strncpy(tmp, name, B_NAME_SIZE_MAX - 1);
+    tmp[B_NAME_SIZE_MAX - 1] = 0;
 
     // Create the variable and copy the value
     var = bmem_var_new(tmp, TOKEN_VARIABLE_STRING, strlen(value), 0);

--- a/lib/basic/bmemory.h
+++ b/lib/basic/bmemory.h
@@ -36,6 +36,9 @@
 #define IO_BUFFER_SIZE  (128)
 #define TOKEN_LINE_SIZE (128)
 #define EVAL_RETURNS_SIZE (32)
+#define B_DIM_MAX (16)
+#define B_DIM_RANGE_FLAG (128)
+#define B_NAME_SIZE_MAX (16)
 
 typedef struct {
     uint16_t line_no;

--- a/lib/basic/eval.c-static
+++ b/lib/basic/eval.c-static
@@ -731,7 +731,6 @@ static bool eval_dim()
         return false;
 
     char *name = bmem->bstate.var_ref;
-    name[0] |= TOKEN_ARRAY_FLAG;
     uint8_t token = name[0];
 
     uint8_t dim = 0;
@@ -751,11 +750,13 @@ static bool eval_dim()
 
     // Copy name in tmp
     char tmp[B_NAME_SIZE_MAX];
+    token |= TOKEN_ARRAY_FLAG;
     strncpy(tmp, name, B_NAME_SIZE_MAX - 1);
     tmp[B_NAME_SIZE_MAX - 1] = 0;
+    tmp[0] = token;
 
     // Remove existing variable
-    var_t *var = bmem_var_find(name);
+    var_t *var = bmem_var_find(tmp);
     if (var)
         bmem_var_unset(var);
 

--- a/lib/basic/eval.c-static
+++ b/lib/basic/eval.c-static
@@ -664,18 +664,20 @@ static bool eval_array_ref(uint8_t token, uint8_t *dim_count, uint32_t *dims)
             break;
         }
 
-        if ((*dim_count & ~B_DIM_RANGE_FLAG) >= B_DIM_MAX - 1)
+        if (bmem->bstate.do_eval)
         {
-            bmem->bstate.error = BERROR_RANGE;
-            return false;
-        }
+            if ((*dim_count & ~B_DIM_RANGE_FLAG) >= B_DIM_MAX - 1)
+            {
+                bmem->bstate.error = BERROR_RANGE;
+                return false;
+            }
 
-        if (bmem->bstate.number < 1 || bmem->bstate.number >= BASTOS_MEMORY_SIZE)
-        {
-            bmem->bstate.error = BERROR_RANGE;
-            return false;
+            if (bmem->bstate.number < 1 || bmem->bstate.number >= BASTOS_MEMORY_SIZE)
+            {
+                bmem->bstate.error = BERROR_RANGE;
+                return false;
+            }
         }
-
         dims[*dim_count] = bmem->bstate.number;
         (*dim_count)++;
 
@@ -794,8 +796,18 @@ static bool eval_let()
 
         if (bmem->bstate.do_eval)
         {
-            if (bmem_var_number_set(name, bmem->bstate.number) == 0)
-                return false;
+            // Manage simple variable
+            if (dim == 0)
+                return bmem_var_number_set(name, bmem->bstate.number) != 0;
+
+            // Manage array
+            float *number = bmem_number_array_get_cell(name, dim, dims);
+            if (!number)
+            {
+                bmem->bstate.error = BERROR_RANGE;
+                return true;
+            }
+            *number = bmem->bstate.number;
         }
         return true;
     }
@@ -809,6 +821,7 @@ static bool eval_let()
             if (dim == 0)
                 return bmem_var_string_set(name, bmem->bstate.string) != 0;
 
+            // TODO: Manage array
             var_t *var = bmem_var_find(name);
             if (!var)
             {

--- a/lib/basic/eval.c-static
+++ b/lib/basic/eval.c-static
@@ -558,19 +558,25 @@ static bool eval_string_var()
     if (!eval_token(TOKEN_VARIABLE_STRING))
         return false;
 
+    char *name = (char *)bmem->bstate.read_ptr - 1;
+    while(*bmem->bstate.read_ptr++);
+
+    uint8_t dim = 0;
+    uint32_t dims[B_DIM_MAX];
+
+    eval_array_ref(TOKEN_VARIABLE_STRING, &dim, dims);
+
     if (bmem->bstate.do_eval)
     {
-        var_t *var = bmem_var_find((char *)bmem->bstate.read_ptr - 1);
-        if (var)
+        bmem->bstate.string = bmem_string_array_get_cell(name, &dim, dims);
+        if (!bmem->bstate.string || dim < 2)
         {
-            bmem->bstate.string = var->string;
+            bmem->bstate.error = dim == 0 ? 0 : BERROR_RANGE;
+            return true;
         }
-        else
-        {
-            bmem->bstate.string = 0;
-        }
+
+        string_slice(&bmem->bstate.string, dims[dim - 2], dims[dim - 1]);
     }
-    while(*bmem->bstate.read_ptr++);
     return true;
 }
 

--- a/lib/basic/eval.c-static
+++ b/lib/basic/eval.c-static
@@ -44,6 +44,8 @@
 
 static inline void eval_input_mode(bool mode);
 static bool eval_string_tty();
+static bool eval_array_ref(uint8_t token, uint8_t *dim_count, uint32_t *dims);
+
 
 extern bastos_io_t *bio;
 extern bmem_t *bmem;
@@ -207,19 +209,39 @@ static bool eval_number()
     }
     else if (eval_token(TOKEN_VARIABLE_NUMBER))
     {
+        char *name = (char *)bmem->bstate.read_ptr - 1;
+        bmem->bstate.read_ptr += strlen(name);
+
+        uint8_t dim = 0;
+        uint32_t dims[B_DIM_MAX];
+
+        eval_array_ref(TOKEN_VARIABLE_NUMBER, &dim, dims);
+
         if (bmem->bstate.do_eval)
         {
-            var_t *var = bmem_var_find((char *)bmem->bstate.read_ptr - 1);
-            if (var)
+            if (dim == 0)
             {
-                value = var->numbers[0];
+                var_t *var = bmem_var_find(name);
+                if (var)
+                {
+                    value = var->numbers[0];
+                }
+                else
+                {
+                    value = 0;
+                }
             }
             else
             {
-                value = 0;
+                float *number = bmem_number_array_get_cell(name, dim, dims);
+                if (!number)
+                {
+                    bmem->bstate.error = BERROR_RANGE;
+                    return false;
+                }
+                value = *number;
             }
         }
-        bmem->bstate.read_ptr += strlen((char *)bmem->bstate.read_ptr) + 1;
     }
     else
     {

--- a/lib/basic/eval.c-static
+++ b/lib/basic/eval.c-static
@@ -646,6 +646,82 @@ static bool eval_variable_ref()
     return true;
 }
 
+static bool eval_array_ref(uint8_t token, uint8_t *dim_count, uint32_t *dims)
+{
+    if (!eval_token('('))
+        return false;
+
+    *dim_count = 0;
+
+    while (eval_float_expr() || eval_token(TOKEN_KEYWORD_TO))
+    {
+
+        if (bmem->bstate.token == TOKEN_KEYWORD_TO)
+        {
+            dims[*dim_count] = 1;
+            (*dim_count)++;
+            (*dim_count) |= B_DIM_RANGE_FLAG;
+            break;
+        }
+
+        if ((*dim_count & ~B_DIM_RANGE_FLAG) >= B_DIM_MAX - 1)
+        {
+            bmem->bstate.error = BERROR_RANGE;
+            return false;
+        }
+
+        if (bmem->bstate.number < 1 || bmem->bstate.number >= BASTOS_MEMORY_SIZE)
+        {
+            bmem->bstate.error = BERROR_RANGE;
+            return false;
+        }
+
+        dims[*dim_count] = bmem->bstate.number;
+        (*dim_count)++;
+
+        if (eval_token(','))
+            continue;
+
+        if (eval_token(TOKEN_KEYWORD_TO))
+        {
+            (*dim_count) |= B_DIM_RANGE_FLAG;
+            break;
+        }
+
+        break;
+    }
+
+    if ((*dim_count & B_DIM_RANGE_FLAG) != 0)
+    {
+        if (eval_float_expr())
+        {
+            if (bmem->bstate.number < 1 || bmem->bstate.number >= BASTOS_MEMORY_SIZE)
+            {
+                bmem->bstate.error = BERROR_RANGE;
+                return false;
+            }
+            dims[*dim_count & ~B_DIM_RANGE_FLAG] = bmem->bstate.number;
+        }
+        else
+        {
+            dims[*dim_count & ~B_DIM_RANGE_FLAG] = BASTOS_MEMORY_SIZE;
+        }
+        (*dim_count)++;
+    }
+
+    if (!eval_token(')'))
+        return false;
+
+    // Normalize last dimension in case of unique string
+    if (token == TOKEN_VARIABLE_STRING && *dim_count == 1)
+    {
+        *dim_count = 2 | B_DIM_RANGE_FLAG;
+        dims[1] = dims[0];
+    }
+
+    return true;
+}
+
 static bool eval_dim()
 {
     if (!eval_token(TOKEN_KEYWORD_DIM))
@@ -654,61 +730,45 @@ static bool eval_dim()
     if (!eval_variable_ref())
         return false;
 
-    // char *name = bmem->bstate.var_ref;
-    // uint8_t token = name[0];
-
-    if (!eval_token('('))
-        return false;
+    char *name = bmem->bstate.var_ref;
+    name[0] |= TOKEN_ARRAY_FLAG;
+    uint8_t token = name[0];
 
     uint8_t dim = 0;
-    uint32_t size = 1;
+    uint32_t dims[B_DIM_MAX];
 
-    while (eval_float_expr())
-    {
-        if (bmem->bstate.do_eval)
-        {
-            if (dim == UINT8_MAX)
-            {
-                bmem->bstate.error = BERROR_RANGE;
-                return true;
-            }
-            if (bmem->bstate.number < 1 || bmem->bstate.number > 16384)
-            {
-                bmem->bstate.error = BERROR_RANGE;
-                return true;
-            }
-            size *= bmem->bstate.number;
-        }
-
-        dim++;
-
-        if (!eval_token(','))
-            break;
-    }
-
-    if (!eval_token(')'))
+    if (!eval_array_ref(token, &dim, dims))
         return false;
 
     if (dim == 0)
         return false;
 
+    if ((dim & B_DIM_RANGE_FLAG) != 0)
+        return false;
+
     if (!bmem->bstate.do_eval)
         return true;
 
+    // Copy name in tmp
+    char tmp[B_NAME_SIZE_MAX];
+    strncpy(tmp, name, B_NAME_SIZE_MAX - 1);
+    tmp[B_NAME_SIZE_MAX - 1] = 0;
 
+    // Remove existing variable
+    var_t *var = bmem_var_find(name);
+    if (var)
+        bmem_var_unset(var);
 
-    // TODO: declare variable and create space for the array
-    bio->print_integer("DIM: %d\r\n", (int) dim);
+    // Create variable
+    var = bmem_var_new(tmp, token, dim, dims);
+    if (!var)
+        bmem->bstate.error = BERROR_MEMORY;
 
     return true;
 }
 
 static bool eval_let()
 {
-    uint16_t start = 1;
-    uint16_t end = UINT16_MAX;
-    bool range = false;
-
     if (!eval_token(TOKEN_KEYWORD_LET))
         return false;
 
@@ -718,31 +778,10 @@ static bool eval_let()
     char *name = bmem->bstate.var_ref;
     uint8_t token = *((uint8_t *)name);
 
-    if (token == TOKEN_VARIABLE_STRING && eval_token('('))
-    {
-        if (eval_expr(TOKEN_NUMBER))
-        {
-            start = bmem->bstate.number;
-            end = start;
-        }
+    uint8_t dim = 0;
+    uint32_t dims[B_DIM_MAX];
 
-        if (eval_token(TOKEN_KEYWORD_TO))
-        {
-            if (eval_expr(TOKEN_NUMBER))
-            {
-                end = bmem->bstate.number;
-            }
-            else
-            {
-                end = UINT16_MAX;
-            }
-        }
-
-        if (!eval_token(')'))
-            return false;
-
-        range = true;
-    }
+    eval_array_ref(token, &dim, dims);
 
     if (!eval_token('='))
         return false;
@@ -766,41 +805,45 @@ static bool eval_let()
 
         if (bmem->bstate.do_eval)
         {
-            if (range)
+            if (dim == 0)
+                return bmem_var_string_set(name, bmem->bstate.string) != 0;
+
+            var_t *var = bmem_var_find(name);
+            if (!var)
             {
-                var_t *var = bmem_var_find(name);
-                uint16_t len = strlen(var->string);
-                if (len == 0)
-                    return true;
-                if (start <= 0)
-                    return true;
-                if (start > len)
-                    return true;
-                if (end < start)
-                    return true;
-                if (end > len)
-                    end = len;
-                uint8_t *src = (uint8_t*) bmem->bstate.string;
-                // FIXME: this is not correct, we should use the char *functions
-                uint8_t *dst = (uint8_t*) var->string + start - 1;
-                uint16_t n = end - start + 1;
-                while (n)
-                {
-                    if (src && *src)
-                    {
-                        *dst++ = *src++;
-                    }
-                    else
-                    {
-                        *dst++ = ' ';
-                    }
-                    n--;
-                }
+                bmem->bstate.error = BERROR_MEMORY;
+                return true;
             }
-            else
+
+            uint16_t len = strlen(var->string);
+            uint16_t start = dim & B_DIM_RANGE_FLAG ? dims[0] : 1;
+            uint16_t end = dim & B_DIM_RANGE_FLAG ? dims[1] : len;
+
+            if (len == 0)
+                return true;
+            if (start <= 0)
+                return true;
+            if (start > len)
+                return true;
+            if (end < start)
+                return true;
+            if (end > len)
+                end = len;
+
+            uint8_t *src = (uint8_t*) bmem->bstate.string;
+            uint8_t *dst = (uint8_t*) var->string + start - 1;
+            uint16_t n = end - start + 1;
+            while (n)
             {
-                if (bmem_var_string_set(name, bmem->bstate.string) == 0)
-                    return false;
+                if (src && *src)
+                {
+                    *dst++ = *src++;
+                }
+                else
+                {
+                    *dst++ = ' ';
+                }
+                n--;
             }
         }
         return true;

--- a/lib/basic/eval.c-static
+++ b/lib/basic/eval.c-static
@@ -711,7 +711,6 @@ static bool eval_array_ref(uint8_t token, uint8_t *dim_count, uint32_t *dims)
             (*dim_count) |= B_DIM_RANGE_FLAG;
             break;
         }
-
         break;
     }
 
@@ -733,17 +732,7 @@ static bool eval_array_ref(uint8_t token, uint8_t *dim_count, uint32_t *dims)
         (*dim_count)++;
     }
 
-    if (!eval_token(')'))
-        return false;
-
-    // Normalize last dimension in case of unique string
-    if (token == TOKEN_VARIABLE_STRING && *dim_count == 1)
-    {
-        *dim_count = 2 | B_DIM_RANGE_FLAG;
-        dims[1] = dims[0];
-    }
-
-    return true;
+    return eval_token(')');
 }
 
 static bool eval_dim()
@@ -843,17 +832,17 @@ static bool eval_let()
             if (dim == 0)
                 return bmem_var_string_set(name, bmem->bstate.string) != 0;
 
-            // TODO: Manage array
-            var_t *var = bmem_var_find(name);
-            if (!var)
+            // Manage array and slice
+            char *string = bmem_string_array_get_cell(name, &dim, dims);
+            if (!string)
             {
-                bmem->bstate.error = BERROR_MEMORY;
+                bmem->bstate.error = BERROR_RANGE;
                 return true;
             }
 
-            uint16_t len = strlen(var->string);
-            uint16_t start = dim & B_DIM_RANGE_FLAG ? dims[0] : 1;
-            uint16_t end = dim & B_DIM_RANGE_FLAG ? dims[1] : len;
+            uint16_t len = strlen(string);
+            uint16_t start = dims[dim - 2];
+            uint16_t end = dims[dim - 1];
 
             if (len == 0)
                 return true;
@@ -867,7 +856,7 @@ static bool eval_let()
                 end = len;
 
             uint8_t *src = (uint8_t*) bmem->bstate.string;
-            uint8_t *dst = (uint8_t*) var->string + start - 1;
+            uint8_t *dst = (uint8_t*) string + start - 1;
             uint16_t n = end - start + 1;
             while (n)
             {

--- a/status.txt
+++ b/status.txt
@@ -280,3 +280,8 @@ Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
 RAM:   [====      ]  39.2% (used 32084 bytes from 81920 bytes)
 Flash: [=====     ]  49.3% (used 472608 bytes from 958448 bytes)
 ---
+Implemented bmem_string_array_get_cell
+Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
+RAM:   [====      ]  39.1% (used 32068 bytes from 81920 bytes)
+Flash: [=====     ]  49.4% (used 473464 bytes from 958448 bytes)
+---

--- a/status.txt
+++ b/status.txt
@@ -280,8 +280,13 @@ Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
 RAM:   [====      ]  39.2% (used 32084 bytes from 81920 bytes)
 Flash: [=====     ]  49.3% (used 472608 bytes from 958448 bytes)
 ---
-Implemented bmem_string_array_get_cell
+3e25a9b Implemented bmem_string_array_get_cell
 Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
 RAM:   [====      ]  39.1% (used 32068 bytes from 81920 bytes)
 Flash: [=====     ]  49.4% (used 473464 bytes from 958448 bytes)
+---
+Impelemented eval_string_var w/ eval_array_ref and bmem_string_array_get_cell
+Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
+RAM:   [====      ]  39.1% (used 32068 bytes from 81920 bytes)
+Flash: [=====     ]  49.4% (used 473624 bytes from 958448 bytes)
 ---

--- a/status.txt
+++ b/status.txt
@@ -285,8 +285,13 @@ Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
 RAM:   [====      ]  39.1% (used 32068 bytes from 81920 bytes)
 Flash: [=====     ]  49.4% (used 473464 bytes from 958448 bytes)
 ---
-Impelemented eval_string_var w/ eval_array_ref and bmem_string_array_get_cell
+72ab6cf Impelemented eval_string_var w/ eval_array_ref and bmem_string_array_get_cell
 Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
 RAM:   [====      ]  39.1% (used 32068 bytes from 81920 bytes)
 Flash: [=====     ]  49.4% (used 473624 bytes from 958448 bytes)
+---
+Fixed indices checking and offset computing
+Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
+RAM:   [====      ]  39.1% (used 32068 bytes from 81920 bytes)
+Flash: [=====     ]  49.4% (used 473672 bytes from 958448 bytes)
 ---


### PR DESCRIPTION
This pull request adds support for accessing individual cells of string and number arrays in the BASIC interpreter. It includes the implementation of the `bmem_string_array_get_cell` and `bmem_number_array_get_cell` functions, and the necessary changes to the `bmem_var_new` and `bmem_var_alloc` functions.